### PR TITLE
Ensure output is copied to a unique scratch directory

### DIFF
--- a/src/HejPythiaJob/run_hejpythia.py
+++ b/src/HejPythiaJob/run_hejpythia.py
@@ -241,7 +241,8 @@ class HejPythiaMerger():
         if self.prune:
             self.prune_script = prune_script
 
-        self.scratch_dir = "/scratch/%s/tmp_output" % (str(user_name))
+        addendum = os.path.basename(os.path.normpath(grid_output_dir))
+        self.scratch_dir = "/scratch/%s/tmp_output_%s" % (str(user_name), str(addendum))
         cmd = "mkdir %s" % self.scratch_dir
         os.system(cmd)
 

--- a/src/JobTemplate/run_job.py
+++ b/src/JobTemplate/run_job.py
@@ -124,7 +124,8 @@ class JobMerger():
         if self.prune:
             self.prune_script = prune_script
 
-        self.scratch_dir = "/scratch/%s/tmp_output" % (str(user_name))
+        addendum = os.path.basename(os.path.normpath(grid_output_dir))
+        self.scratch_dir = "/scratch/%s/tmp_output_%s" % (str(user_name), str(addendum))
         cmd = "mkdir %s" % self.scratch_dir
         os.system(cmd)
 

--- a/src/SherpaCKKWLJob/run_sherpackkwl.py
+++ b/src/SherpaCKKWLJob/run_sherpackkwl.py
@@ -245,7 +245,8 @@ class SherpaCKKWLMerger():
         if self.prune:
             self.prune_script = prune_script
 
-        self.scratch_dir = "/scratch/%s/tmp_output" % (str(user_name))
+        addendum = os.path.basename(os.path.normpath(grid_output_dir))
+        self.scratch_dir = "/scratch/%s/tmp_output_%s" % (str(user_name), str(addendum))
         cmd = "mkdir %s" % self.scratch_dir
         os.system(cmd)
 


### PR DESCRIPTION
The base path of the grid output directory is used to make a unique scratch directory per submission